### PR TITLE
feat: implement exchange_code_for_session for PKCE flow

### DIFF
--- a/lib/supabase/go_true.ex
+++ b/lib/supabase/go_true.ex
@@ -391,4 +391,32 @@ defmodule Supabase.GoTrue do
       User.Identity.parse_list(response.body)
     end
   end
+
+  @doc """
+  Exchanges an authorization code for a session.
+
+  Used in the PKCE (Proof Key for Code Exchange) flow to convert an authorization code
+  into a valid session using a code_verifier that matches the previously sent code_challenge.
+
+  ## Parameters
+    * `client` - The `Supabase` client to use for the request.
+    * `auth_code` - The authorization code received from the OAuth provider.
+    * `code_verifier` - The original code verifier that was used to generate the code challenge.
+    * `opts` - Additional options:
+      * `redirect_to` - The URL to redirect to after successful authentication.
+      
+  ## Examples
+      iex> auth_code = "received_auth_code"
+      iex> code_verifier = "original_code_verifier"
+      iex> Supabase.GoTrue.exchange_code_for_session(client, auth_code, code_verifier)
+      {:ok, %Supabase.GoTrue.Session{}}
+  """
+  @impl true
+  @spec exchange_code_for_session(Client.t(), String.t(), String.t(), map()) ::
+          {:ok, Session.t()} | {:error, term}
+  def exchange_code_for_session(%Client{} = client, auth_code, code_verifier, opts \\ %{}) do
+    with {:ok, resp} <- UserHandler.exchange_code_for_session(client, auth_code, code_verifier, opts) do
+      Session.parse(resp.body)
+    end
+  end
 end

--- a/lib/supabase/go_true_behaviour.ex
+++ b/lib/supabase/go_true_behaviour.ex
@@ -16,4 +16,5 @@ defmodule Supabase.GoTrueBehaviour do
   @callback sign_in_with_id_token(Client.t(), map) :: sign_in_response
   @callback sign_in_with_password(Client.t(), map) :: sign_in_response
   @callback sign_up(Client.t(), map) :: {:ok, User.t(), binary} | {:error, Supabase.Error.t()}
+  @callback exchange_code_for_session(Client.t(), String.t(), String.t(), map()) :: sign_in_response
 end


### PR DESCRIPTION
## Problem

  Authentication using the PKCE (Proof Key for Code Exchange) flow requires a method to
  exchange the authorization code for a session, but this functionality was missing from
  the library.

  ## Solution

  Implemented exchange_code_for_session/4 which allows exchanging an authorization code
  for a valid session token using a code verifier in the PKCE flow.

 ## Rationale

  PKCE is a more secure authorization flow that protects against authorization code
  interception attacks, particularly important for public clients. This implementation
  follows OAuth 2.0 best practices and completes the authentication process flow for
  applications using PKCE.