### PR TITLE
feat: implement reauthentication functionality

### DIFF
--- a/lib/supabase/go_true.ex
+++ b/lib/supabase/go_true.ex
@@ -419,4 +419,26 @@ defmodule Supabase.GoTrue do
       Session.parse(resp.body)
     end
   end
+
+  @doc """
+  Sends a reauthentication request for the authenticated user.
+
+  This method is typically used when performing sensitive operations that require 
+  recent authentication. It sends a one-time password (OTP) to the user's email
+  or phone number, which they need to verify to confirm their identity.
+
+  ## Parameters
+    * `client` - The `Supabase` client to use for the request.
+    * `session` - The current user session containing the access token.
+
+  ## Examples
+      iex> session = %Supabase.GoTrue.Session{access_token: "example_token"}
+      iex> Supabase.GoTrue.reauthenticate(client, session)
+      :ok
+  """
+  @impl true
+  @spec reauthenticate(Client.t(), Session.t()) :: :ok | {:error, term}
+  def reauthenticate(%Client{} = client, %Session{} = session) do
+    UserHandler.reauthenticate(client, session.access_token)
+  end
 end

--- a/lib/supabase/go_true/user_handler.ex
+++ b/lib/supabase/go_true/user_handler.ex
@@ -34,6 +34,7 @@ defmodule Supabase.GoTrue.UserHandler do
   @identities_uri "/identities"
   @identity_authorize_uri "/identities/authorize"
   @token_uri "/token"
+  @reauthenticate_uri "/reauthenticate"
 
   def get_user(%Client{} = client, access_token) when is_binary(access_token) do
     client
@@ -471,6 +472,32 @@ defmodule Supabase.GoTrue.UserHandler do
   end
 
   def get_user_identities(%Client{}, nil) do
+    {:error, %Supabase.Error{message: "Missing access token", code: :unauthorized}}
+  end
+
+  @doc """
+  Sends a reauthentication request for the authenticated user.
+
+  This sends a reauthentication OTP to the user's email or phone number. 
+  Requires the user to be authenticated with a valid session.
+
+  ## Parameters
+    * `client` - The `Supabase` client to use for the request.
+    * `access_token` - The access token of the current session.
+  """
+  def reauthenticate(%Client{} = client, access_token) when is_binary(access_token) do
+    client
+    |> GoTrue.Request.base(@reauthenticate_uri)
+    |> Request.with_headers(%{"authorization" => "Bearer #{access_token}"})
+    |> Request.with_method(:get)
+    |> Fetcher.request()
+    |> case do
+      {:ok, _} -> :ok
+      err -> err
+    end
+  end
+
+  def reauthenticate(%Client{}, nil) do
     {:error, %Supabase.Error{message: "Missing access token", code: :unauthorized}}
   end
 end

--- a/lib/supabase/go_true_behaviour.ex
+++ b/lib/supabase/go_true_behaviour.ex
@@ -17,4 +17,5 @@ defmodule Supabase.GoTrueBehaviour do
   @callback sign_in_with_password(Client.t(), map) :: sign_in_response
   @callback sign_up(Client.t(), map) :: {:ok, User.t(), binary} | {:error, Supabase.Error.t()}
   @callback exchange_code_for_session(Client.t(), String.t(), String.t(), map()) :: sign_in_response
+  @callback reauthenticate(Client.t(), Session.t()) :: :ok | {:error, Supabase.Error.t()}
 end


### PR DESCRIPTION
## Problem

When users need to perform sensitive operations (like changing passwords or managing
security settings), applications should verify their identity with a recent
authentication. However, requiring a full sign-in process for these operations creates
unnecessary friction.

## Solution

Implemented the reauthenticate/2 function that sends an OTP (one-time password) to the
user's email or phone number without requiring a complete sign-in flow. This allows
applications to verify user identity for sensitive operations with minimal disruption.

Closes #24

## Rationale

This implementation follows the security best practice of re-confirming user identity
for sensitive operations while maintaining a good user experience. The approach:
- Uses the existing authentication infrastructure with a dedicated endpoint
- Requires only a valid session token, avoiding unnecessary credential input
- Returns clear responses (:ok or error) for simple integration
- Follows the established pattern of other authentication functions in the library
