### PR TITLE
fix: coorectly handle single strategy on auth generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2025-05-20
+
+### Fixed
+- Correctly hadnle single strategy on mix task generator
+
 ## [0.5.0] - 2025-05-18
 
 ### Added

--- a/lib/mix/tasks/supabase.gen.auth.ex
+++ b/lib/mix/tasks/supabase.gen.auth.ex
@@ -255,14 +255,15 @@ defmodule Mix.Tasks.Supabase.Gen.Auth do
     auth_only: {:boolean, {:default, false}}
 
   defp validate_options!(options) do
+    strategies =
+      Enum.reduce(options, [], fn
+        {:strategy, strategy}, acc -> [strategy | acc]
+        _, acc -> acc
+      end)
+
     options
-    |> Enum.group_by(fn {k, _} -> k end)
-    |> Enum.map(fn {k, v} ->
-      {k,
-       v
-       |> Enum.map(fn {_, v} -> v end)
-       |> then(&if length(&1) == 1, do: hd(&1), else: &1)}
-    end)
+    |> Enum.reject(&match?({:strategy, _}, &1))
+    |> Keyword.put(:strategy, strategies)
     |> config!()
     |> then(fn opts ->
       client = opts[:client]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule SupabaseAuth.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.5.1"
   @source_url "https://github.com/supabase-community/auth-ex"
 
   def project do


### PR DESCRIPTION
## Problem

The mix task for generation of auth files was wrongly parsing a single strategy

## Solution

Filter strategues directly from options before parsing the options keyword against the schema

## Rationale

N/A
