### PR TITLE
fix: captcha token for anonymous users

### DIFF
--- a/lib/supabase/go_true/schemas/sign_in_request.ex
+++ b/lib/supabase/go_true/schemas/sign_in_request.ex
@@ -6,6 +6,7 @@ defmodule Supabase.GoTrue.Schemas.SignInRequest do
   import Ecto.Changeset
   import Supabase.GoTrue.Validations
 
+  alias Supabase.GoTrue.Schemas.SignInAnonymously
   alias Supabase.GoTrue.Schemas.SignInWithIdToken
   alias Supabase.GoTrue.Schemas.SignInWithOTP
   alias Supabase.GoTrue.Schemas.SignInWithPassword
@@ -100,6 +101,16 @@ defmodule Supabase.GoTrue.Schemas.SignInRequest do
     |> put_embed(:gotrue_meta_security, gotrue_meta, required: true)
     |> validate_required([:password])
     |> validate_required_inclusion([:email, :phone])
+    |> apply_action(:insert)
+  end
+
+  def create(%SignInAnonymously{} = signin) do
+    attrs = SignInAnonymously.to_sign_in_params(signin)
+    gotrue_meta = %__MODULE__.GoTrueMetaSecurity{captcha_token: signin.captcha_token}
+
+    %__MODULE__{}
+    |> cast(attrs, [:data])
+    |> put_embed(:gotrue_meta_security, gotrue_meta, required: true)
     |> apply_action(:insert)
   end
 

--- a/lib/supabase/go_true/user.ex
+++ b/lib/supabase/go_true/user.ex
@@ -18,6 +18,7 @@ defmodule Supabase.GoTrue.User do
   * `confirmed_at` - Timestamp when the user was confirmed (email verification)
   * `factors` - Multi-factor authentication methods associated with the user
   * `identities` - External identity providers linked to this user (GitHub, Google, etc.)
+  * `is_anonymous` - Set to true if user is authenticated as anonymous
 
   ## Confirmation Status
 
@@ -74,11 +75,12 @@ defmodule Supabase.GoTrue.User do
           role: String.t() | nil,
           updated_at: NaiveDateTime.t() | nil,
           identities: list(Identity) | nil,
-          factors: list(Factor) | nil
+          factors: list(Factor) | nil,
+          is_anonymous: boolean | nil
         }
 
   @required_fields ~w[id app_metadata aud created_at]a
-  @optional_fields ~w[confirmation_sent_at recovery_sent_at email_change_sent_at new_email new_phone invited_at action_link email phone confirmed_at email_confirmed_at phone_confirmed_at last_sign_in_at role]a
+  @optional_fields ~w[confirmation_sent_at recovery_sent_at email_change_sent_at new_email new_phone invited_at action_link email phone confirmed_at email_confirmed_at phone_confirmed_at last_sign_in_at role is_anonymous]a
 
   @derive Jason.Encoder
   @primary_key {:id, :binary_id, autogenerate: false}
@@ -101,6 +103,7 @@ defmodule Supabase.GoTrue.User do
     field(:last_sign_in_at, :naive_datetime)
     field(:encrypted_password, :string)
     field(:role, :string)
+    field(:is_anonymous, :boolean)
 
     embeds_many(:factors, Factor)
     embeds_many(:identities, Identity)

--- a/lib/supabase/go_true/user_handler.ex
+++ b/lib/supabase/go_true/user_handler.ex
@@ -124,12 +124,14 @@ defmodule Supabase.GoTrue.UserHandler do
     end
   end
 
-  def sign_in_anonymously(%Client{} = client, %SignInAnonymously{} = opts) do
-    client
-    |> GoTrue.Request.base(@sign_up_uri)
-    |> Request.with_method(:post)
-    |> Request.with_body(%{"options" => opts})
-    |> Fetcher.request()
+  def sign_in_anonymously(%Client{} = client, %SignInAnonymously{} = signin) do
+    with {:ok, body} <- SignInRequest.create(signin) do
+      client
+      |> GoTrue.Request.base(@sign_up_uri)
+      |> Request.with_method(:post)
+      |> Request.with_body(body)
+      |> Fetcher.request()
+    end
   end
 
   @grant_types ~w[password id_token]

--- a/test/supabase/go_true_test.exs
+++ b/test/supabase/go_true_test.exs
@@ -550,10 +550,7 @@ defmodule Supabase.GoTrueTest do
       expect(@mock, :request, fn %Request{} = req, _opts ->
         assert req.method == :post
         assert req.url.path =~ "/signup"
-
-        assert %{
-                 "options" => %{"captcha_token" => "123"}
-               } = Jason.decode!(req.body)
+        assert %{"gotrue_meta_security" => %{"captcha_token" => "123"}} = Jason.decode!(req.body)
 
         user = [id: "123", identities: []] |> user_fixture() |> Map.from_struct()
         body = session_fixture_json(access_token: "123", user: user)


### PR DESCRIPTION
## Problem

The payload for anonymous users was wrong

## Solution

Fix payload and add `is_anonymous` field for `User`

## Rationale

N/A
