### PR TITLE
fix: missing skip_http_redirect on query param when linking identity

### DIFF
--- a/lib/supabase/go_true/request.ex
+++ b/lib/supabase/go_true/request.ex
@@ -11,6 +11,7 @@ defmodule Supabase.GoTrue.Request do
     |> Request.with_auth_url(path)
     |> Request.with_http_client(http_client())
     |> Request.with_headers(%{"accept" => "application/json"})
+    |> Request.with_body_decoder(__MODULE__.JSONDecoder)
   end
 
   defp http_client do

--- a/lib/supabase/go_true/user_handler.ex
+++ b/lib/supabase/go_true/user_handler.ex
@@ -437,7 +437,7 @@ defmodule Supabase.GoTrue.UserHandler do
 
   def link_identity(%Client{} = client, access_token, %SignInWithOauth{} = oauth) when is_binary(access_token) do
     oauth_query = SignInWithOauth.options_to_query(oauth)
-    query = Map.new(oauth_query, fn {k, v} -> {to_string(k), v} end)
+    query = oauth_query |> Map.new(fn {k, v} -> {to_string(k), v} end) |> Map.put("skip_http_redirect", true)
 
     client
     |> GoTrue.Request.base(@single_user_uri <> @identity_authorize_uri)


### PR DESCRIPTION
## Problem

when calling `link_identity/3` we were missing the `skip_http_redirect` query params, which was causing the API request to return HTML, which then failed on JSON decoding

## Solution

add the missing query params, now the function is correctly return the map with `url` field

## Rationale

Close #37 
